### PR TITLE
docs(README): refresh to current facts + org MD conventions (H548)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCS — Cappeller *Sanskrit-Wörterbuch* (1887)
 
-_Created: 16-05-2026 · Last updated: 05-07-2026_
+_Created: 16-05-2026 · Last updated: 11-07-2026_
 
 Development and correction repository for **Carl Cappeller's *Sanskrit-Wörterbuch***, a Sanskrit→German dictionary, part of the [Cologne Digital Sanskrit Lexicon](https://www.sanskrit-lexicon.uni-koeln.de/) (CDSL). The canonical source text lives in [`csl-orig/v02/ccs/ccs.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/master/v02/ccs/ccs.txt) (28,751 entries); this repository holds the development, correction, and enrichment work.
 
@@ -8,15 +8,17 @@ Based largely on the Petersburg Wörterbuch (CCS ⊆ PW ≈ 0.945 by headword co
 
 ## Documentation
 
-- [CLAUDE.md](CLAUDE.md) — repository guide and data-format reference.
-- [DATA_DICTIONARY.md](DATA_DICTIONARY.md) — markup tag reference.
-- [CONTRIBUTING.md](CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [CLAUDE.md](https://github.com/sanskrit-lexicon/CCS/blob/main/CLAUDE.md) — repository guide and data-format reference.
+- [DATA_DICTIONARY.md](https://github.com/sanskrit-lexicon/CCS/blob/main/DATA_DICTIONARY.md) — markup tag reference.
+- [CONTRIBUTING.md](https://github.com/sanskrit-lexicon/CCS/blob/main/CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](https://github.com/sanskrit-lexicon/CCS/blob/main/CODE_OF_CONDUCT.md)
+- Corrections follow the canonical CDSL workflow — see [`csl-corrections/docs/correction-workflow.md`](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
 
 ## Contents
 
 | Path | Purpose |
 |---|---|
-| `verbs01/` | Verb identification: maps verb entries to MW roots, with Devanāgarī renderings |
+| [`verbs01/`](https://github.com/sanskrit-lexicon/CCS/tree/main/verbs01) | Verb identification: maps verb entries to MW roots, with Devanāgarī renderings |
+| [`prefaces/`](https://github.com/sanskrit-lexicon/CCS/tree/main/prefaces) | Front-matter OCR + English and Russian translations of the 1887 *Vorrede* |
 
 ## Usage example
 
@@ -26,7 +28,7 @@ A real entry from [`csl-orig/v02/ccs/ccs.txt`](https://github.com/sanskrit-lexic
 88:{#akaRwaka#}¦ dornen-, feindlos.
 ```
 
-To correct the German gloss (e.g. `dornen-, feindlos` → `dornenlos, feindlos`, a compound-hyphenation fix), write a paired-line change file and apply it with `updateByLine.py`:
+To correct the German gloss (e.g. `dornen-, feindlos` → `dornenlos, feindlos`, a compound-hyphenation fix), write a paired-line change file and apply it with `updateByLine.py` (full workflow: [`csl-corrections/docs/correction-workflow.md`](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md)):
 
 ```
 ; issueNNN: fix compound hyphenation in "akaRwaka" gloss
@@ -39,14 +41,6 @@ python updateByLine.py ccs.txt change_88.txt ccs_corrected.txt
 ```
 
 (Illustrative — no actual defect at this line; the workflow above is exact, only the fictitious hyphenation fix is invented to demonstrate the change-file mechanics.)
-
-## Timeline
-
-| Period | Activity |
-|---|---|
-| 2020 | Repository activity begins (first tracked issues) |
-| 2021–2021 | Ongoing corrections, markup, and comparison work |
-| 2026-05 | Issue taxonomy, citation metadata, documentation |
 
 ## Projects & Milestones
 
@@ -80,14 +74,14 @@ pie showData
 
 | # | Title | Type | Severity | Milestone |
 |---|---|---|---|---|
-| 1 | verbs01 | content-enhancement | medium | Major Enhancements |
-| 2 | New CCS Scan | scan-quality | minor | Digitization Quality |
+| [1](https://github.com/sanskrit-lexicon/CCS/issues/1) | verbs01 | content-enhancement | medium | Major Enhancements |
+| [2](https://github.com/sanskrit-lexicon/CCS/issues/2) | New CCS Scan | scan-quality | minor | Digitization Quality |
 
 ### Solved
 
 | # | Title | Type | Severity | Milestone |
 |---|---|---|---|---|
-| 3 | [markup] Minor ccs.txt Markup Oddities | markup | minor | Structured Data |
+| [3](https://github.com/sanskrit-lexicon/CCS/issues/3) | [markup] Minor ccs.txt Markup Oddities | markup | minor | Structured Data |
 
 ## Labels
 
@@ -113,12 +107,16 @@ pie showData
 | `medium` | Standard unit of work — one batch of corrections |
 | `hard` | Large effort spanning many sources or files |
 
+Full label colours and the type→milestone mapping live in the [Cologne issue runbook](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-issue-runbook.md).
+
 ## Contributors
 
 | Contributor | Commits |
 |---|---|
-| gasyoun (Mārcis Gasūns) | 8 |
-| funderburkjim | 3 |
+| [gasyoun (Mārcis Gasūns)](https://github.com/gasyoun) | 28 |
+| [funderburkjim](https://github.com/funderburkjim) | 3 |
+
+_Commit counts per the GitHub contributors API; excludes automated (Dependabot) commits._
 
 ## Source
 
@@ -129,7 +127,7 @@ pie showData
 - **Language pair**: Sanskrit → German
 - **Size (CDSL headword index)**: 28,751 entries
 - **License (digital edition)**: CC BY-SA 4.0
-- See [CITATION.cff](CITATION.cff) for machine-readable citation.
+- See [CITATION.cff](https://github.com/sanskrit-lexicon/CCS/blob/main/CITATION.cff) for machine-readable citation.
 
 ## Encoding
 
@@ -159,28 +157,28 @@ OCR transcription + English and Russian translations of the dictionary's front m
 - Folder index: [`prefaces/README.md`](https://github.com/sanskrit-lexicon/CCS/blob/main/prefaces/README.md).
 - Five Devanāgarī example words in the Vorrede (p. VII) are transcribed verbatim with their printed accent marks: अनन्यमानस, चतुर्धा, इष्टि, स्वयुज्, कथावशेष.
 
-<details>
-<summary><strong>OCR run notes (2026-06-22)</strong> — cost, timing, and technical lessons</summary>
-
-Produced by the `/cologne-preface-ocr` skill (vision OCR + translation, single agent, synchronous). Process retrospective, not part of the deliverable.
-
-**Cost.** All work done in one foreground agent — no OCR/translation subagents were spawned. The cost is dominated by ~40 native-resolution crop reads (title/dedication bands, four dense single-column preface pages cut into 4–6 bands each, plus 3× zoom tiles to verify the five Devanāgarī words on p. VII). Main thread ≈ **0.6–0.8 M tokens** total.
-
-**Time.** Wall-clock ≈ 15 min. Gated mainly by the gentle one-at-a-time scan download (server was recently throttling) and the iterative Devanāgarī word-tile zooming.
-
-**Technical lessons (reusable):**
-1. 6 scans, all single embedded `_images/ccs_Page_0NN_Image_0002.png`; toctree order = filename order here (no swap).
-2. Pages 03–06 are single-column dense prose (not two-column) — full-width native bands of ~780 px tall scale cleanly to ≤1900 px.
-3. The five Devanāgarī example words on p. VII needed individual 3× tiles to pin the accent strokes (udātta vertical bar over इ in इष्टि and over यु in स्वयुज्); band-level reads were not enough.
-4. Cappeller uses the long-ſ ligature in *Maſsstabe / bloſs / auſser / groſsen*; transcribed with `ſ`/`ſs` where printed.
-
-</details>
+> **OCR run notes (2026-06-22)** — process retrospective, not part of the deliverable.
+>
+> Produced by the `/cologne-preface-ocr` skill (vision OCR + translation, single agent, synchronous).
+>
+> **Cost.** All work done in one foreground agent — no OCR/translation subagents were spawned. The cost is dominated by ~40 native-resolution crop reads (title/dedication bands, four dense single-column preface pages cut into 4–6 bands each, plus 3× zoom tiles to verify the five Devanāgarī words on p. VII). Main thread ≈ 0.6–0.8 M tokens total.
+>
+> **Time.** Wall-clock ≈ 15 min. Gated mainly by the gentle one-at-a-time scan download (server was recently throttling) and the iterative Devanāgarī word-tile zooming.
+>
+> **Technical lessons (reusable):**
+> 1. 6 scans, all single embedded `_images/ccs_Page_0NN_Image_0002.png`; toctree order = filename order here (no swap).
+> 2. Pages 03–06 are single-column dense prose (not two-column) — full-width native bands of ~780 px tall scale cleanly to ≤1900 px.
+> 3. The five Devanāgarī example words on p. VII needed individual 3× tiles to pin the accent strokes (udātta vertical bar over इ in इष्टि and over यु in स्वयुज्); band-level reads were not enough.
+> 4. Cappeller uses the long-ſ ligature in *Maſsstabe / bloſs / auſser / groſsen*; transcribed with `ſ`/`ſs` where printed.
 
 ## Timeline
 
-| Date | Work |
+| Period | Activity |
 |---|---|
-| Jun 2026 | Front-matter OCR + EN/RU translation of the preface (`prefaces/`) |
+| 2020 | Repository activity begins (first tracked issues) |
+| 2021 | Ongoing corrections, markup, and comparison work |
+| 2026-05 | Issue taxonomy, citation metadata, documentation |
+| 2026-06 | Front-matter OCR + EN/RU translation of the preface (`prefaces/`) |
 
 ---
 *Issue taxonomy and documentation per the [Cologne issue runbook](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-issue-runbook.md).*


### PR DESCRIPTION
Part of **H548** (README audit + refactor across Cologne dictionary repos) — see [H548 handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H548-Opus_Uprava_readme-refresh-dict-repos_10.07.26.md).

Refreshes [`README.md`](https://github.com/sanskrit-lexicon/CCS/blob/main/README.md) so every status claim is currently true and applies org Markdown conventions.

## Changes
- **Dated header + byline** added (`_Created: 16-05-2026 · Last updated: 11-07-2026_`; creation date from `git log --follow --diff-filter=A`).
- **No raw HTML** — the `<details>`/`<summary>` OCR-notes block is now a blockquote.
- **Full `blob`/`tree` URLs** for every path/link; issue rows and contributor names now link out.
- **Contributor counts corrected** to the live GitHub contributors API (gasyoun 28, funderburkjim 3 — was a stale 8/3).
- **Merged the two duplicate `## Timeline` sections** into one.
- Added a link to the canonical [`csl-corrections/docs/correction-workflow.md`](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md); added `prefaces/` to the Contents table.

## Verification
Issue and milestone tables were checked against `gh api` / `gh issue list` and are **currently accurate** (issues 1 & 2 OPEN, issue 3 CLOSED; milestone counts unchanged). No facts invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)